### PR TITLE
Allow authentication caller to provide raw hashed challenge

### DIFF
--- a/types.go
+++ b/types.go
@@ -76,6 +76,10 @@ type AuthenticateRequest struct {
 	// Optional boolean (defaults to false) to use WebAuthn authentication with U2f
 	// devices
 	WebAuthn bool
+
+	// Optional boolean (defaults to false) that indicates the Challenge string is a raw
+	// base64 websafe SHA256 hash that should be used directly as the authentication challenge
+	RawChallenge bool
 }
 
 // A response from an Authenticate operation.


### PR DESCRIPTION
Some uses of FIDO2 authentication do not use a hashed JSON challenge, but instead their own data blob that is SHA256 hashed in the same fashion. An example of this is the use of FIDO2 keys with SSH. Provide a mechanism for indicating that the caller has already calculated the hash.

Tested with a Go SSH/FIDO2 agent implementation.